### PR TITLE
feat: add support for suite before and after

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,12 +33,20 @@ proc someAsyncProc {.async.} =
 
 suite "test async proc":
 
+  setupAll:
+    # invoke await in the suite setup:
+    await someAsyncProc()
+
+  teardownAll:
+    # invoke await in the suite teardown:
+    await someAsyncProc()
+
   setup:
-    # invoke await in the test setup:
+    # invoke await in each test setup:
     await someAsyncProc()
 
   teardown:
-    # invoke await in the test teardown:
+    # invoke await in each test teardown:
     await someAsyncProc()
 
   test "async test":

--- a/asynctest/templates.nim
+++ b/asynctest/templates.nim
@@ -1,5 +1,17 @@
 template suite*(name, body) =
+
   suite name:
+
+    # Runs before all tests in the suite
+    template setupAll(setupAllBody) {.used.} =
+      let b = proc {.async.} = setupAllBody
+      waitFor b()
+
+    # Runs after all tests in the suite
+    template teardownAll(teardownAllBody) {.used.} =
+      template teardownAllIMPL: untyped {.inject.} =
+        let a = proc {.async.} = teardownAllBody
+        waitFor a()
 
     template setup(setupBody) {.used.} =
       setup:
@@ -11,7 +23,12 @@ template suite*(name, body) =
         let asyncproc = proc {.async.} = teardownBody
         waitFor asyncproc()
 
-    let suiteproc = proc = body # Avoids GcUnsafe2 warnings with chronos
+    let suiteproc = proc = # Avoids GcUnsafe2 warnings with chronos
+      body
+
+      when declared(teardownAllIMPL):
+        teardownAllIMPL()
+
     suiteproc()
 
 template test*(name, body) =

--- a/testmodules/stdlib/testbody.nim
+++ b/testmodules/stdlib/testbody.nim
@@ -15,3 +15,17 @@ suite "test async proc":
   test "async test":
     # invoke await in tests:
     await someAsyncProc()
+
+suite "test async setupAll and teardownAll, allow multiple suites":
+
+  setupAll:
+    # invoke await in the test setup:
+    await someAsyncProc()
+
+  teardownAll:
+    # invoke await in the test teardown:
+    await someAsyncProc()
+
+  test "async test":
+    # invoke await in tests:
+    await someAsyncProc()


### PR DESCRIPTION
`before` executes async code before all tests in the suite.
`after` executes async code after all tests in the suite.

Example:
```nim
suite "Example":

  proc printAsync(msg: string) {.async.} =
    debugEcho msg
    await sleepAsync 1.milliseconds

  before:
    await printAsync "BEFORE"

  after:
    await printAsync "AFTER"

  setup:
    await printAsync "SETUP"

  teardown:
    await printAsync "TEARDOWN"

  test "#1":
    await printAsync "Test #1"

  test "#2":
    await printAsync "Test #2"

  test "#3":
    await printAsync "Test #3"
```
Running the above test suite produces the following output:
```bash
[Suite] Example
BEFORE
SETUP
Test #1
TEARDOWN
  [OK] #1
SETUP
Test #2
TEARDOWN
  [OK] #2
SETUP
Test #3
TEARDOWN
  [OK] #3
AFTER
```
