### PR TITLE
`check eventually` (removes Nim 1.2. compatibility)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        nim: [stable, 1.2.6]
+        nim: [stable, 1.6.12]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,26 @@ last resort when setting up the test environment is very costly. Be careful that
 the tests do not modify the environment that you set up, lest you introduce
 dependencies between tests.
 
+check eventually
+----------------
+
+When you find yourself adding calls to `sleepAsync` to your tests, you might
+want to consider using `check eventually` instead. It will repeatedly check
+an expression until it becomes true. It has a built-in timeout of 5 seconds that
+you can override.
+
+```nim
+var x: int
+
+proc slowProcedure {.async.} =
+  # perform a slow operation
+  x = 42
+
+let future = slowProcedure()
+check eventually x == 42
+await future
+```
+
 Unittest2
 ---------
 

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ Use the [Nimble][2] package manager to add asynctest to an existing project.
 Add the following to its .nimble file:
 
 ```nim
-requires "asynctest >= 0.3.2 & < 0.4.0"
+requires "asynctest >= 0.4.0 & < 0.5.0"
 ```
 
 Usage

--- a/asynctest.nimble
+++ b/asynctest.nimble
@@ -1,4 +1,4 @@
-version = "0.3.2"
+version = "0.4.0"
 author = "asynctest Authors"
 description = "Test asynchronous code"
 license = "MIT"

--- a/asynctest/eventually.nim
+++ b/asynctest/eventually.nim
@@ -1,0 +1,19 @@
+import std/times
+
+template eventually*(expression: untyped, timeout=5000): bool =
+
+  template sleep(millis: int): auto =
+    when compiles(await sleepAsync(millis.milliseconds)):
+      sleepAsync(millis.milliseconds) # chronos
+    else:
+      sleepAsync(millis) # asyncdispatch
+
+  proc eventually: Future[bool] {.async.} =
+    let endTime = getTime() + initDuration(milliseconds=timeout)
+    while not expression:
+      if endTime < getTime():
+        return false
+      await sleep(10)
+    return true
+
+  await eventually()

--- a/asynctest/unittest.nim
+++ b/asynctest/unittest.nim
@@ -1,4 +1,7 @@
 import std/unittest
+import ./eventually
+
 export unittest except suite, test
+export eventually
 
 include ./templates

--- a/asynctest/unittest2.nim
+++ b/asynctest/unittest2.nim
@@ -1,4 +1,7 @@
 import pkg/unittest2
+import ./eventually
+
 export unittest2 except suite, test
+export eventually
 
 include ./templates

--- a/testmodules/chronos/test.nimble
+++ b/testmodules/chronos/test.nimble
@@ -6,4 +6,4 @@ license = "MIT"
 requires "chronos"
 
 task test, "Runs the test suite":
-  exec "nim c -f -r test.nim"
+  exec "nim c -f -r --skipParentCfg test.nim"

--- a/testmodules/stdlib/test.nimble
+++ b/testmodules/stdlib/test.nimble
@@ -4,4 +4,4 @@ description = "Asynctest tests for std/unittest and std/asyncdispatch"
 license = "MIT"
 
 task test, "Runs the test suite":
-  exec "nim c -f -r test.nim"
+  exec "nim c -f -r --skipParentCfg test.nim"

--- a/testmodules/unittest2/test.nimble
+++ b/testmodules/unittest2/test.nimble
@@ -7,4 +7,4 @@ requires "unittest2"
 requires "chronos"
 
 task test, "Runs the test suite":
-  exec "nim c -f -r test.nim"
+  exec "nim c -f -r --skipParentCfg test.nim"


### PR DESCRIPTION
Adds `check eventually` template that allows a test to wait for a condition to become true.

Breaks compatibility with older Nim versions.