### PR TITLE
Fix warning when using `check eventually` with chronos

### DIFF
--- a/asynctest/eventually.nim
+++ b/asynctest/eventually.nim
@@ -1,4 +1,4 @@
-import std/times
+import std/times except milliseconds
 
 template eventually*(expression: untyped, timeout=5000): bool =
 


### PR DESCRIPTION
Would call `sleepAsync(10)` instead of `sleepAsync(10.milliseconds)`, which prompts a deprecation warning from chronos.