### PR TITLE
Updates for Chronos V4

### DIFF
--- a/asynctest/templates.nim
+++ b/asynctest/templates.nim
@@ -1,3 +1,18 @@
+template launderExceptions(body: typed) =
+  ## Chronos V4 requires that all procs which raise Exception annotate it
+  ## with {.async: (raises: [Exception]).}, but this construct does not
+  ## exist in asyncdispatch. We therefore launder all real instances of
+  ## Exception into CatchableError and make Chronos happy while not losing
+  ## context information for the remainder of the exception types.
+  try:
+    body
+  except Defect as ex:
+    raise ex
+  except CatchableError as ex:
+    raise ex
+  except Exception as ex:
+    raise newException(CatchableError, ex.msg, ex)
+
 template suite*(name, body) =
 
   suite name:
@@ -10,18 +25,18 @@ template suite*(name, body) =
     ## Runs after all tests in the suite
     template teardownAll(teardownAllBody) {.used.} =
       template teardownAllIMPL: untyped {.inject.} =
-        let a = proc {.async.} = teardownAllBody
+        let a = proc {.async.} = launderExceptions: teardownAllBody
         waitFor a()
 
     template setup(setupBody) {.used.} =
       setup:
-        let asyncproc = proc {.async.} = setupBody
+        let asyncproc = proc {.async.} = launderExceptions: setupBody
         waitFor asyncproc()
 
     template teardown(teardownBody) {.used.} =
       teardown:
         let exception = getCurrentException()
-        let asyncproc = proc {.async.} = teardownBody
+        let asyncproc = proc {.async.} = launderExceptions: teardownBody
         waitFor asyncproc()
         setCurrentException(exception)
 
@@ -35,5 +50,5 @@ template suite*(name, body) =
 
 template test*(name, body) =
   test name:
-    let asyncproc = proc {.async.} = body
+    let asyncproc = proc {.async.} = launderExceptions: body
     waitFor asyncproc()

--- a/asynctest/templates.nim
+++ b/asynctest/templates.nim
@@ -4,14 +4,18 @@ template launderExceptions(body: typed) =
   ## exist in asyncdispatch. We therefore launder all real instances of
   ## Exception into CatchableError and make Chronos happy while not losing
   ## context information for the remainder of the exception types.
+  {.push warning[BareExcept]:off.}
   try:
+    {.push warning[BareExcept]:on.}
     body
+    {.pop.}
   except Defect as ex:
     raise ex
   except CatchableError as ex:
     raise ex
   except Exception as ex:
     raise newException(Defect, ex.msg, ex)
+  {.pop.}
 
 template suite*(name, body) =
 

--- a/asynctest/templates.nim
+++ b/asynctest/templates.nim
@@ -11,7 +11,7 @@ template launderExceptions(body: typed) =
   except CatchableError as ex:
     raise ex
   except Exception as ex:
-    raise newException(CatchableError, ex.msg, ex)
+    raise newException(Defect, ex.msg, ex)
 
 template suite*(name, body) =
 

--- a/testmodules/stdlib/testfail.nim
+++ b/testmodules/stdlib/testfail.nim
@@ -26,7 +26,7 @@ suite "reports unhandled exception when teardown handles exceptions too":
     teardown:
       try:
         await someAsyncProc()
-      except:
+      except CatchableError:
         discard
 
     test "should fail, but not crash":

--- a/testmodules/unittest2/test.nimble
+++ b/testmodules/unittest2/test.nimble
@@ -3,7 +3,7 @@ author = "Asynctest Authors"
 description = "Asynctest tests for pkg/unittest2 and pkg/chronos"
 license = "MIT"
 
-requires "unittest2"
+requires "unittest2 <= 0.0.9"
 requires "chronos"
 
 task test, "Runs the test suite":


### PR DESCRIPTION
Chronos does not allow code to raise plain `Exception` without changes to the async signature, and this was creating issues when using, for instance, chronos and unittest (you'd get things like `unittest.nim(613, 16) Error: failureOccurred(formatter, checkpoints, "") can raise an unlisted exception: Exception`).

Since changing async signatures to `{.async: (raises: [Exception]).}` would break compatibility with asyncdispatch, this PR adds a shim which traps and launders true `Exception` instances into `CatchableError`, which Chronos V4 allows.

It also pins unittest2 to `<= 0.0.9` as `0.1.0` introduces breaking changes which should be addressed elsewhere.