### PR TITLE
Fix for unittest2 > 0.0.9

### DIFF
--- a/asynctest/templates.nim
+++ b/asynctest/templates.nim
@@ -20,31 +20,31 @@ template launderExceptions(body: typed) =
 template suite*(name, body) =
 
   suite name:
-
-    ## Runs before all tests in the suite
-    template setupAll(setupAllBody) {.used.} =
-      let b = proc {.async.} = launderExceptions: setupAllBody
-      waitFor b()
-
-    ## Runs after all tests in the suite
-    template teardownAll(teardownAllBody) {.used.} =
-      template teardownAllIMPL: untyped {.inject.} =
-        let a = proc {.async.} = launderExceptions: teardownAllBody
-        waitFor a()
-
-    template setup(setupBody) {.used.} =
-      setup:
-        let asyncproc = proc {.async.} = launderExceptions: setupBody
-        waitFor asyncproc()
-
-    template teardown(teardownBody) {.used.} =
-      teardown:
-        let exception = getCurrentException()
-        let asyncproc = proc {.async.} = launderExceptions: teardownBody
-        waitFor asyncproc()
-        setCurrentException(exception)
-
     let suiteproc = proc = # Avoids GcUnsafe2 warnings with chronos
+
+      ## Runs before all tests in the suite
+      template setupAll(setupAllBody) {.used.} =
+        let b = proc {.async.} = launderExceptions: setupAllBody
+        waitFor b()
+
+      ## Runs after all tests in the suite
+      template teardownAll(teardownAllBody) {.used.} =
+        template teardownAllIMPL: untyped {.inject.} =
+          let a = proc {.async.} = launderExceptions: teardownAllBody
+          waitFor a()
+
+      template setup(setupBody) {.used.} =
+        setup:
+          let asyncproc = proc {.async.} = launderExceptions: setupBody
+          waitFor asyncproc()
+
+      template teardown(teardownBody) {.used.} =
+        teardown:
+          let exception = getCurrentException()
+          let asyncproc = proc {.async.} = launderExceptions: teardownBody
+          waitFor asyncproc()
+          setCurrentException(exception)
+
       body
 
       when declared(teardownAllIMPL):

--- a/testmodules/unittest2/test.nimble
+++ b/testmodules/unittest2/test.nimble
@@ -3,7 +3,7 @@ author = "Asynctest Authors"
 description = "Asynctest tests for pkg/unittest2 and pkg/chronos"
 license = "MIT"
 
-requires "unittest2 <= 0.0.9"
+requires "unittest2"
 requires "chronos"
 
 task test, "Runs the test suite":


### PR DESCRIPTION
Define our templates inside a new scope, to make sure that they don't clash with the unittest2 templates.