### PR TITLE
Exception handling for Chronos V4 in eventually

### DIFF
--- a/asynctest/private/chronos/eventually.nim
+++ b/asynctest/private/chronos/eventually.nim
@@ -1,9 +1,19 @@
 import pkg/chronos
+import pkg/chronos/config
+
+template eventuallyProcSignature(body: untyped): untyped =
+  when compiles(config.chronosHandleException):
+    proc eventually: Future[bool] {.async: (handleException: true,
+        raises: [AsyncExceptionError, CancelledError]).} =
+      body
+  else:
+    proc eventually: Future[bool] {.async.} =
+      body
 
 template eventually*(expression: untyped, timeout=5000): bool =
   bind Moment, now, milliseconds
 
-  proc eventually: Future[bool] {.async.} =
+  eventuallyProcSignature:
     let endTime = Moment.now() + timeout.milliseconds
     while not expression:
       if endTime < Moment.now():

--- a/testmodules/chronosv4/test.nim
+++ b/testmodules/chronosv4/test.nim
@@ -9,3 +9,10 @@ suite "eventually and std/times":
 
   test "compiles when both chronos and std/times are imported":
     check eventually true
+
+  test "compiles when the expression handed to eventually can raise Exception":
+    proc aProc(): bool {.raises: [Exception].} = raise newException(
+      Exception, "an exception")
+    check:
+      compiles:
+        discard eventually aProc()


### PR DESCRIPTION
Expressions handed over to `eventually` may raise `Exception` leading compilation to fail under Chronos V4. This PR adds a conditional signature to `eventually`, similar to what we did with [runAsync](https://github.com/codex-storage/asynctest/blob/main/asynctest/private/chronos/unittest/runasync.nim#L4), to fix this.