### PR TITLE
feat: add tunable polling interval with conservative defaults

### DIFF
--- a/asynctest/private/asyncdispatch/eventually.nim
+++ b/asynctest/private/asyncdispatch/eventually.nim
@@ -1,14 +1,14 @@
 import std/asyncdispatch
 import std/times
 
-template eventually*(expression: untyped, timeout=5000): bool =
+template eventually*(expression: untyped, timeout=5000, pollInterval=1000): bool =
 
   proc eventually: Future[bool] {.async.} =
     let endTime = getTime() + initDuration(milliseconds=timeout)
     while not expression:
       if endTime < getTime():
         return false
-      await sleepAsync(10)
+      await sleepAsync(pollInterval)
     return true
 
   await eventually()

--- a/asynctest/private/chronos/eventually.nim
+++ b/asynctest/private/chronos/eventually.nim
@@ -10,7 +10,7 @@ template eventuallyProcSignature(body: untyped): untyped =
     proc eventually: Future[bool] {.async.} =
       body
 
-template eventually*(expression: untyped, timeout=5000): bool =
+template eventually*(expression: untyped, timeout=5000, pollInterval=1000): bool =
   bind Moment, now, milliseconds
 
   eventuallyProcSignature:
@@ -18,7 +18,7 @@ template eventually*(expression: untyped, timeout=5000): bool =
     while not expression:
       if endTime < Moment.now():
         return false
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(pollInterval.milliseconds)
     return true
 
   await eventually()


### PR DESCRIPTION
Predicate checks are currently very aggressive with polling, and this can easily trip people if they stuff things like HTTP requests inside. This PR adds a tunable polling interval with a conservative default.